### PR TITLE
refactor(cloudflared): update HelmRelease configuration and improve ingress service references

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/configs/config.yaml
@@ -7,10 +7,10 @@ originRequest:
 
 ingress:
   - hostname: "${SECRET_DOMAIN}"
-    service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
+    service: &internal_svc https://ingress-nginx-external-controller.network.svc.cluster.local:443
   - hostname: "*.${SECRET_DOMAIN}"
-    service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
+    service: *internal_svc
   - hostname: "${SECRET_DOMAIN_WEB_CABINET}"
-    service: https://ingress-nginx-external-controller.network.svc.cluster.local:443
+    service: *internal_svc
     originServerName: "external.${SECRET_DOMAIN_WEB_CABINET}"
   - service: http_status:404

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -1,21 +1,17 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cloudflared
 spec:
-  interval: 30m
-  chart:
-    spec:
-      chart: app-template
-      version: 3.7.3
-      sourceRef:
-        kind: HelmRepository
-        name: bjw-s
-        namespace: flux-system
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
   install:
     remediation:
-      retries: 3
+      retries: -1
   upgrade:
     cleanupOnFail: true
     remediation:
@@ -33,22 +29,14 @@ spec:
               tag: 2025.4.2
             env:
               NO_AUTOUPDATE: true
-              TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json
               TUNNEL_METRICS: 0.0.0.0:8080
               TUNNEL_ORIGIN_ENABLE_HTTP2: true
-              TUNNEL_TRANSPORT_PROTOCOL: quic
               TUNNEL_POST_QUANTUM: true
-              TUNNEL_ID:
-                valueFrom:
-                  secretKeyRef:
-                    name: cloudflared-secret
-                    key: TUNNEL_ID
-            args:
-              - tunnel
-              - --config
-              - /etc/cloudflared/config/config.yaml
-              - run
-              - "$(TUNNEL_ID)"
+              TUNNEL_TRANSPORT_PROTOCOL: quic
+            envFrom:
+              - secretRef:
+                  name: cloudflared-secret
+            args: ["tunnel", "run"]
             probes:
               liveness: &probes
                 enabled: true
@@ -97,13 +85,6 @@ spec:
         type: configMap
         name: cloudflared-configmap
         globalMounts:
-          - path: /etc/cloudflared/config/config.yaml
+          - path: /etc/cloudflared/config.yaml
             subPath: config.yaml
-            readOnly: true
-      creds:
-        type: secret
-        name: cloudflared-secret
-        globalMounts:
-          - path: /etc/cloudflared/creds/credentials.json
-            subPath: credentials.json
             readOnly: true


### PR DESCRIPTION
- Changed HelmRelease interval from 30m to 1h.
- Updated chart reference to use OCIRepository.
- Modified install remediation retries to -1 for unlimited retries.
- Simplified environment variable references by using envFrom for secrets.
- Consolidated ingress service definitions to use an anchor for better maintainability.
