### PR TITLE
feat(external-secrets): migrate ExternalSecret resources to API v1

### DIFF
--- a/kubernetes/apps/databases/emqx/app/externalsecret.yaml
+++ b/kubernetes/apps/databases/emqx/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: emqx
@@ -20,8 +20,8 @@ spec:
     - extract:
         key: emqx
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: emqx-init-user

--- a/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: qbittorrent

--- a/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home/home-assistant/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: home-assistant

--- a/kubernetes/apps/home/zigbee2mqtt/app/externalsecret.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/externalsecret.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: zigbee2mqtt


### PR DESCRIPTION
## Summary
- Migrated all ExternalSecret resources from v1beta1 to v1 API version
- Updated YAML language server schemas to match v1 API specifications
- Maintained backward compatibility with existing configurations

## Changes
- Updated 5 ExternalSecret resources across 4 files:
  - `kubernetes/apps/databases/emqx/app/externalsecret.yaml` (2 resources)
  - `kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml` (1 resource)
  - `kubernetes/apps/home/home-assistant/app/externalsecret.yaml` (1 resource)
  - `kubernetes/apps/home/zigbee2mqtt/app/externalsecret.yaml` (1 resource)

## Test plan
- [ ] Verify all ExternalSecret resources apply successfully
- [ ] Confirm secrets are still properly synchronized
- [ ] Check that applications using the secrets remain functional
- [ ] Validate YAML language server schemas work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)